### PR TITLE
feat: Add full internationalization (i18n) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 # 🎶 Jukebox RFID MP3 Player
 
-Este projeto transforma um Raspberry Pi em uma Jukebox de MP3 controlada por cartões RFID. Use a interface web para fazer upload de suas músicas, associar cada música a um cartão RFID e, em seguida, simplesmente aproxime o cartão do leitor para tocar sua música.
+## 🌐 Language / Idioma
+
+- [🇧🇷 Português](#-português)
+- [🇺🇸 English](#-english)
 
 ---
+## 🇧🇷 Português
+
+Este projeto transforma um Raspberry Pi em uma Jukebox de MP3 controlada por cartões RFID. Use a interface web para fazer upload de suas músicas, associar cada música a um cartão RFID e, em seguida, simplesmente aproxime o cartão do leitor para tocar sua música.
 
 ### ✨ Funcionalidades
 
 - **Playback por RFID:** Associe arquivos MP3 a cartões RFID e toque-os instantaneamente.
 - **Interface Web Completa:** Controle a reprodução (play/pause), ajuste o volume e veja a música que está tocando.
+- **Interface Multilíngue:** Alterne entre Português e Inglês com um clique.
 - **Upload de Músicas:** Arraste e solte seus arquivos MP3 diretamente na interface web para adicioná-los à sua biblioteca.
 - **Associação de Cartões Simplificada:** Após o upload de uma música, a interface pede que você escaneie um cartão para criar a associação.
 - **Instalação Automatizada:** O script `install.sh` configura todas as dependências de software, incluindo `pygame` para áudio e as bibliotecas GPIO.
@@ -101,11 +108,12 @@ Siga estes passos para configurar sua Jukebox do zero.
 ### 🎶 Como Usar
 
 1.  **Acesse a Interface Web:** Após a instalação, o serviço iniciará automaticamente. Encontre o IP do seu Raspberry Pi e acesse `http://<IP-do-seu-Pi>:5000` em um navegador na mesma rede.
-2.  **Faça o Upload de uma Música:** Na interface, arraste um arquivo MP3 para a área de upload designada.
-3.  **Associe um Cartão:** Após o upload ser bem-sucedido, a interface mostrará a mensagem: *"Arquivo 'nome-da-musica.mp3' salvo. Aproxime um cartão para associar."*
-4.  **Escaneie o Cartão:** Aproxime um cartão RFID do leitor. O sistema irá associar permanentemente esse cartão à música que você acabou de enviar.
-5.  **Toque sua Música:** Agora, sempre que você aproximar esse cartão do leitor, a música associada começará a tocar.
-6.  **Controle a Reprodução:** Use os botões de play/pause e o controle de volume na interface web para gerenciar a música.
+2.  **Escolha o Idioma:** Use as bandeiras 🇧🇷 / 🇺🇸 no canto superior direito para alternar o idioma da interface.
+3.  **Faça o Upload de uma Música:** Na interface, arraste um arquivo MP3 para a área de upload designada.
+4.  **Associe um Cartão:** Após o upload ser bem-sucedido, a interface mostrará a mensagem: *"Arquivo 'nome-da-musica.mp3' salvo. Aproxime um cartão para associar."*
+5.  **Escaneie o Cartão:** Aproxime um cartão RFID do leitor. O sistema irá associar permanentemente esse cartão à música que você acabou de enviar.
+6.  **Toque sua Música:** Agora, sempre que você aproximar esse cartão do leitor, a música associada começará a tocar.
+7.  **Controle a Reprodução:** Use os botões de play/pause e o controle de volume na interface web para gerenciar a música.
 
 ### 📁 Estrutura do Projeto
 
@@ -116,11 +124,140 @@ Siga estes passos para configurar sua Jukebox do zero.
 │   ├── player.py           # Classe que gerencia a reprodução de áudio com pygame.
 │   ├── rfid.py             # Módulo para comunicação de baixo nível com o leitor RC522.
 │   ├── static/style.css    # Folha de estilos da interface web.
-│   └── template/index.html # Estrutura HTML da interface web.
+│   ├── template/index.html # Estrutura HTML da interface web.
+│   └── translations.json   # Arquivo com as traduções da UI.
 ├── music/                  # Diretório onde os MP3s enviados são armazenados.
 ├── install.sh              # Script de instalação e configuração.
 ├── qr_generator.py         # Gera um QR code para acesso fácil à interface.
 ├── requirements.txt        # Dependências Python do projeto.
 └── tags.txt                # Arquivo de texto que armazena as associações (UID -> MP3).
+```
+
+---
+## 🇺🇸 English
+
+This project transforms a Raspberry Pi into an MP3 Jukebox controlled by RFID cards. Use the web interface to upload your music, associate each song with an RFID card, and then simply tap the card on the reader to play your music.
+
+### ✨ Features
+
+- **RFID Playback:** Associate MP3 files with RFID cards and play them instantly.
+- **Complete Web Interface:** Control playback (play/pause), adjust the volume, and see the currently playing song.
+- **Multilingual Interface:** Switch between Portuguese and English with one click.
+- **Music Upload:** Drag and drop your MP3 files directly into the web interface to add them to your library.
+- **Simplified Card Association:** After uploading a song, the interface prompts you to scan a card to create the association.
+- **Automated Installation:** The `install.sh` script configures all software dependencies, including `pygame` for audio and GPIO libraries.
+- **Standalone Service:** Runs as a background service (`systemd`) that starts automatically with the Raspberry Pi.
+
+### ✅ Hardware Requirements
+
+- **Raspberry Pi:** Tested on Pi 2 W, but should work on newer models.
+- **RFID Reader:** RC522 reader connected via SPI.
+- **RFID Cards/Tags:** Compatible with the RC522 reader (e.g., MIFARE Classic).
+- **Audio Output:**
+    - The standard Pi audio output (3.5mm or HDMI).
+    - Or a DAC HAT, such as the **Waveshare HiFi DAC HAT**.
+
+### 🔧 Hardware Setup
+
+#### RFID RC522 Reader Pinout
+Connect the reader to the Raspberry Pi using the following GPIO pins:
+
+| RC522 Pin  | Raspberry Pi GPIO | Pi Name     | Function              |
+|------------|-------------------|-------------|-----------------------|
+| SDA (CS)   | GPIO 8            | SPI0_CE0    | Chip Select           |
+| SCK (CLK)  | GPIO 11           | SPI0_SCLK   | Clock                 |
+| MOSI       | GPIO 10           | SPI0_MOSI   | Master Out Slave In   |
+| MISO       | GPIO 9            | SPI0_MISO   | Master In Slave Out   |
+| IRQ        | -                 | -           | (not used)            |
+| GND        | GND               | GND         | Ground                |
+| RST        | GPIO 25           | GPIO 25     | Reset                 |
+| 3.3V       | 3.3V              | 3.3V        | Power                 |
+
+**Important:** The RFID library used in this project does not utilize the `RST` pin. It can be left disconnected.
+
+#### Note on the Waveshare HiFi HAT
+This project uses `pygame.mixer` to control audio, which in turn uses the ALSA system on Linux. The volume control in the web interface does **not** use `amixer` and should work with any standard output device. If you need command-line volume control, you may need to identify your HAT's mixer control name with the `amixer` command and adjust scripts accordingly.
+
+### 🚀 Complete Installation Guide
+
+Follow these steps to set up your Jukebox from scratch.
+
+#### Step 1: Preparing the Raspberry Pi
+
+1.  **Install Raspberry Pi OS:** Use the [Raspberry Pi Imager](https://www.raspberrypi.com/software/) to install the latest version of Raspberry Pi OS on an SD card.
+2.  **First Boot and Setup:** Start your Raspberry Pi, connect it to your Wi-Fi network, and complete the initial setup.
+3.  **Open the Terminal:** You can do this directly on the Pi's desktop or via SSH.
+4.  **Update Your System:** It's always good practice to ensure your system is up to date.
+    ```bash
+    sudo apt update && sudo apt upgrade -y
+    ```
+5.  **Enable the SPI Interface:** The RC522 reader uses the SPI interface, which must be enabled.
+    ```bash
+    sudo raspi-config
+    ```
+    - Navigate to `3 Interface Options`.
+    - Select `I4 SPI`.
+    - Choose `<Yes>` to enable the SPI interface.
+    - Exit `raspi-config`.
+
+#### Step 2: Connecting the Hardware
+
+1.  **Shut Down the Raspberry Pi:** Before connecting any components, shut down the Pi completely.
+    ```bash
+    sudo shutdown -h now
+    ```
+2.  **Connect the RC522 Reader:** Use the pinout table in the "Hardware Setup" section above to connect the reader to your Raspberry Pi's GPIO pins.
+
+#### Step 3: Installing the Jukebox Software
+
+1.  **Power On the Raspberry Pi:** Reconnect the power to turn on the Pi.
+2.  **Clone the Repository:** Open the terminal and clone this project.
+    ```bash
+    git clone https://github.com/rafaeltini/jukebox_rfid.git
+    cd jukebox_rfid
+    ```
+3.  **Run the Install Script:** This script automates the entire process.
+    ```bash
+    bash install.sh
+    ```
+    - In the menu, type `1` and press Enter to start the full installation.
+    - The script will install all necessary dependencies and set up the Jukebox software to start automatically with the system.
+
+#### Step 4: Finding and Using the Jukebox
+
+1.  **Find the Pi's IP Address:** You'll need the IP to access the web interface.
+    ```bash
+    hostname -I
+    ```
+    Note the first IP address that appears (e.g., `192.168.1.15`).
+2.  **Access the Interface:** On another device on the same network (your computer or phone), open a browser and go to `http://<Your-Pi-IP>:5000`, replacing `<Your-Pi-IP>` with the address you noted.
+3.  **Start Using:** You're all set! Follow the instructions in the "How to Use" section below to add your music.
+
+### 🎶 How to Use
+
+1.  **Access the Web Interface:** After installation, the service will start automatically. Find your Raspberry Pi's IP address and go to `http://<Your-Pi-IP>:5000` in a browser on the same network.
+2.  **Choose the Language:** Use the 🇧🇷 / 🇺🇸 flags in the top-right corner to switch the interface language.
+3.  **Upload a Song:** In the interface, drag and drop an MP3 file into the designated upload area.
+4.  **Associate a Card:** After a successful upload, the interface will display the message: *"File 'song-name.mp3' saved. Scan a card to associate."*
+5.  **Scan the Card:** Tap an RFID card on the reader. The system will permanently associate that card with the song you just uploaded.
+6.  **Play Your Music:** Now, whenever you tap that card on the reader, its associated song will begin to play.
+7.  **Control Playback:** Use the play/pause buttons and the volume slider in the web interface to manage the music.
+
+### 📁 Project Structure
+
+```
+.
+├── app/
+│   ├── main.py             # Main application (Flask), API, and RFID logic.
+│   ├── player.py           # Class that manages audio playback with pygame.
+│   ├── rfid.py             # Low-level communication module for the RC522 reader.
+│   ├── static/style.css    # Stylesheet for the web interface.
+│   ├── template/index.html # HTML structure for the web interface.
+│   └── translations.json   # File with the UI translations.
+├── music/                  # Directory where uploaded MP3s are stored.
+├── install.sh              # Installation and setup script.
+├── qr_generator.py         # Generates a QR code for easy access to the interface.
+├── requirements.txt        # Python project dependencies.
+└── tags.txt                # Text file that stores the associations (UID -> MP3).
 ```
 ```

--- a/app/main.py
+++ b/app/main.py
@@ -1,31 +1,41 @@
-# Importa as bibliotecas necessárias
+# PT: Importa as bibliotecas necessárias
+# EN: Imports the necessary libraries
 from flask import Flask, render_template, request, jsonify
 import os
 import threading
-from app.player import Player  # Importa a nova classe de player
-from app.rfid import read_uid   # Importa a função de leitura de RFID
+import json
+from app.player import Player
+from app.rfid import read_uid
 
-# Configurações
+# PT: Configurações Globais
+# EN: Global Settings
 MUSIC_FOLDER = "music"
 TAGS_FILE = "tags.txt"
+TRANSLATIONS_FILE = "app/translations.json"
 
-# Inicializa a aplicação Flask
+# PT: Inicializa a aplicação Flask
+# EN: Initializes the Flask application
 app = Flask(__name__, template_folder='template', static_folder='static')
 app.config['UPLOAD_FOLDER'] = MUSIC_FOLDER
 
-# Cria uma instância única (singleton) do nosso Player
+# PT: Cria uma instância única (singleton) do nosso Player
+# EN: Creates a single (singleton) instance of our Player
 player = Player()
 
-# Estado global para comunicação entre a thread da web e a thread RFID
+# PT: Estado global para comunicação entre a thread da web e a thread RFID
+# EN: Global state for communication between the web thread (Flask) and the RFID thread
 assignment_state = {
     "pending_file": None,
     "lock": threading.Lock()
 }
 
-# --- Funções de Lógica da Jukebox ---
+# --- Funções de Lógica da Jukebox / Jukebox Logic Functions ---
 
 def get_song_for_tag(uid):
-    """Busca no arquivo de tags a música associada a um UID de cartão."""
+    """
+    PT: Busca no arquivo de tags a música associada a um determinado UID de cartão.
+    EN: Searches the tags file for the song associated with a given card UID.
+    """
     if not os.path.exists(TAGS_FILE):
         return None
     with open(TAGS_FILE, "r") as f:
@@ -37,27 +47,33 @@ def get_song_for_tag(uid):
     return None
 
 def assign_song_to_tag(uid, song_filename):
-    """Salva a associação de um UID com um nome de arquivo de música."""
+    """
+    PT: Salva a associação de um UID com um nome de arquivo de música.
+    EN: Saves the association of a UID with a music filename.
+    """
     with open(TAGS_FILE, "a") as f:
         f.write(f"{uid}:{song_filename}\n")
-    print(f"Associação salva: {uid} -> {song_filename}")
+    print(f"Associação salva (Association saved): {uid} -> {song_filename}")
 
-# --- Lógica do Leitor RFID em Background ---
+# --- Lógica do Leitor RFID em Background / RFID Reader Background Logic ---
 
 def rfid_listener():
-    """Função que roda em uma thread para escutar por cartões RFID."""
-    print("RFID Listener: Thread iniciada.")
+    """
+    PT: Função que roda em uma thread para escutar por cartões RFID.
+    EN: Function that runs in a thread to listen for RFID cards.
+    """
+    print("RFID Listener: Thread iniciada (Thread started).")
     while True:
         uid = read_uid()
         if not uid:
             continue
 
-        print(f"RFID Listener: Cartão '{uid}' escaneado.")
+        print(f"RFID Listener: Cartão escaneado (Card scanned) '{uid}'.")
 
         with assignment_state["lock"]:
             pending_file = assignment_state["pending_file"]
             if pending_file:
-                print(f"RFID Listener: Associando cartão '{uid}' com o arquivo '{pending_file}'.")
+                print(f"RFID Listener: Associando cartão (Associating card) '{uid}' com o arquivo (with file) '{pending_file}'.")
                 assign_song_to_tag(uid, pending_file)
                 player.play(os.path.join(MUSIC_FOLDER, pending_file))
                 assignment_state["pending_file"] = None
@@ -67,25 +83,33 @@ def rfid_listener():
         if song_path:
             player.play(song_path)
         else:
-            print(f"RFID Listener: Nenhuma música encontrada para o cartão '{uid}'.")
+            print(f"RFID Listener: Nenhuma música encontrada para o cartão (No song found for card) '{uid}'.")
 
-# --- Rotas da API ---
+# --- Rotas da API / API Routes ---
 
 @app.route('/')
 def index():
+    # PT: Rota principal que serve a interface web.
+    # EN: Main route that serves the web interface.
     return render_template('index.html')
 
 @app.route('/api/status', methods=['GET'])
 def status():
+    # PT: Endpoint para obter o estado atual do player.
+    # EN: Endpoint to get the current player state.
     return jsonify(player.get_status())
 
 @app.route('/api/play_pause', methods=['POST'])
 def play_pause():
+    # PT: Endpoint para alternar entre play e pause.
+    # EN: Endpoint to toggle between play and pause.
     player.toggle_play_pause()
     return jsonify(player.get_status())
 
 @app.route('/api/volume', methods=['POST'])
 def volume():
+    # PT: Endpoint para ajustar o volume.
+    # EN: Endpoint to adjust the volume.
     level = int(request.json.get('level', 50))
     volume_float = max(0, min(100, level)) / 100.0
     player.set_volume(volume_float)
@@ -93,37 +117,55 @@ def volume():
 
 @app.route('/api/upload', methods=['POST'])
 def upload_file():
-    """Endpoint para upload de arquivos MP3."""
+    # PT: Endpoint para upload de arquivos MP3.
+    # EN: Endpoint for uploading MP3 files.
     if 'file' not in request.files:
-        return jsonify({"status": "error", "message": "Nenhum arquivo enviado"}), 400
+        return jsonify({"status": "error", "message": "Nenhum arquivo enviado (No file sent)"}), 400
 
     file = request.files['file']
     if file.filename == '':
-        return jsonify({"status": "error", "message": "Nenhum arquivo selecionado"}), 400
+        return jsonify({"status": "error", "message": "Nenhum arquivo selecionado (No file selected)"}), 400
 
     if file and file.filename.endswith('.mp3'):
         filename = file.filename
         save_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
         file.save(save_path)
 
-        # Inicia o modo de associação
+        # PT: Inicia o modo de associação
+        # EN: Initiates assignment mode
         with assignment_state["lock"]:
             assignment_state["pending_file"] = filename
 
         return jsonify({"status": "success", "message": f"Arquivo '{filename}' salvo. Aproxime um cartão para associar."})
 
-    return jsonify({"status": "error", "message": "Arquivo inválido. Apenas MP3 são permitidos."}), 400
+    return jsonify({"status": "error", "message": "Arquivo inválido. Apenas MP3 são permitidos. (Invalid file. Only MP3s are allowed.)"}), 400
 
-# --- Ponto de Entrada da Aplicação ---
+@app.route('/api/translations', methods=['GET'])
+def get_translations():
+    # PT: Endpoint que serve o arquivo de traduções.
+    # EN: Endpoint that serves the translations file.
+    try:
+        with open(TRANSLATIONS_FILE, 'r', encoding='utf-8') as f:
+            translations = json.load(f)
+        return jsonify(translations)
+    except FileNotFoundError:
+        return jsonify({"status": "error", "message": "Arquivo de traduções não encontrado (Translations file not found)."}), 404
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+# --- Ponto de Entrada da Aplicação / Application Entry Point ---
 
 if __name__ == '__main__':
-    # Garante que a pasta de música exista
+    # PT: Garante que a pasta de música exista
+    # EN: Ensures the music folder exists
     if not os.path.exists(MUSIC_FOLDER):
         os.makedirs(MUSIC_FOLDER)
 
-    # Inicia a thread do leitor RFID em modo daemon
+    # PT: Inicia a thread do leitor RFID em modo daemon
+    # EN: Starts the RFID reader thread in daemon mode
     listener_thread = threading.Thread(target=rfid_listener, daemon=True)
     listener_thread.start()
 
-    # Executa o servidor Flask
+    # PT: Executa o servidor Flask
+    # EN: Runs the Flask server
     app.run(host='0.0.0.0', port=5000, debug=False)

--- a/app/player.py
+++ b/app/player.py
@@ -3,40 +3,45 @@ import os
 
 class Player:
     """
-    Uma classe singleton para controlar a reprodução de música usando pygame.
-    Gerencia o estado do player (faixa atual, volume, status de reprodução).
+    PT: Uma classe singleton para controlar a reprodução de música usando pygame.
+        Gerencia o estado do player (faixa atual, volume, status de reprodução).
+    EN: A singleton class to control music playback using pygame.
+        Manages the player's state (current track, volume, playback status).
     """
     _instance = None
 
-    # Padrão Singleton para garantir que apenas uma instância do player exista
+    # PT: Padrão Singleton para garantir que apenas uma instância do player exista.
+    # EN: Singleton pattern to ensure that only one instance of the player exists.
     def __new__(cls, *args, **kwargs):
         if not cls._instance:
             cls._instance = super(Player, cls).__new__(cls)
         return cls._instance
 
     def __init__(self):
-        # Evita a re-inicialização
+        # PT: Evita a re-inicialização da instância já existente.
+        # EN: Prevents re-initialization of the existing instance.
         if hasattr(self, '_initialized'):
             return
 
-        print("Inicializando o Player de áudio (pygame)...")
+        print("Inicializando o Player de áudio (pygame)... / Initializing audio player (pygame)...")
         pygame.mixer.init()
         self.current_song = None
         self.is_playing = False
         self.is_paused = False
-        self.volume = 0.5  # Volume padrão de 50%
+        self.volume = 0.5  # PT: Volume padrão de 50% | EN: Default volume of 50%
         pygame.mixer.music.set_volume(self.volume)
         self._initialized = True
 
     def play(self, song_path):
         """
-        Carrega e toca uma nova música. Se uma música já estiver tocando, ela é parada.
+        PT: Carrega e toca uma nova música. Se uma música já estiver tocando, ela é parada.
+        EN: Loads and plays a new song. If a song is already playing, it is stopped.
         """
         if not os.path.exists(song_path):
-            print(f"Erro: Arquivo de áudio não encontrado em '{song_path}'")
+            print(f"Erro: Arquivo de áudio não encontrado em (Error: Audio file not found at) '{song_path}'")
             return
 
-        print(f"Tocando: {song_path}")
+        print(f"Tocando (Now Playing): {song_path}")
         self.current_song = song_path
         pygame.mixer.music.load(song_path)
         pygame.mixer.music.play()
@@ -45,36 +50,40 @@ class Player:
 
     def toggle_play_pause(self):
         """
-        Alterna entre tocar e pausar a música atual.
+        PT: Alterna entre tocar e pausar a música atual.
+        EN: Toggles between playing and pausing the current song.
         """
         if not self.is_playing:
             return
 
         if self.is_paused:
-            print("Continuando a música.")
+            print("Continuando a música (Resuming music).")
             pygame.mixer.music.unpause()
             self.is_paused = False
         else:
-            print("Pausando a música.")
+            print("Pausando a música (Pausing music).")
             pygame.mixer.music.pause()
             self.is_paused = True
 
     def set_volume(self, level):
         """
-        Define o volume.
+        PT: Define o volume.
+        EN: Sets the volume.
 
         Args:
-            level (float): Um valor entre 0.0 e 1.0.
+            level (float): PT: Um valor entre 0.0 e 1.0. | EN: A value between 0.0 and 1.0.
         """
         self.volume = max(0.0, min(1.0, level))
-        print(f"Ajustando volume para: {self.volume:.2f}")
+        print(f"Ajustando volume para (Adjusting volume to): {self.volume:.2f}")
         pygame.mixer.music.set_volume(self.volume)
 
     def get_status(self):
         """
-        Retorna o estado atual do player.
+        PT: Retorna o estado atual do player.
+        EN: Returns the current state of the player.
         """
-        # pygame.mixer.music.get_busy() retorna True se algo estiver tocando (mesmo que pausado)
+        # PT: pygame.mixer.music.get_busy() retorna True se algo estiver tocando (mesmo que pausado).
+        # EN: pygame.mixer.music.get_busy() returns True if something is playing (even if paused).
         self.is_playing = pygame.mixer.music.get_busy()
 
         return {

--- a/app/rfid.py
+++ b/app/rfid.py
@@ -1,5 +1,7 @@
-# Este arquivo contém a lógica para interagir com o leitor RFID RC522.
-# Ele usa a biblioteca mfrc522 e RPi.GPIO para comunicação com o hardware.
+# PT: Este arquivo contém a lógica para interagir com o leitor RFID RC522.
+#     Ele usa a biblioteca mfrc522 e RPi.GPIO para comunicação com o hardware.
+# EN: This file contains the logic for interacting with the RC522 RFID reader.
+#     It uses the mfrc522 library and RPi.GPIO for hardware communication.
 
 import RPi.GPIO as GPIO
 from mfrc522 import MFRC522
@@ -7,61 +9,75 @@ import time
 
 def read_uid():
     """
-    Aguarda a aproximação de um cartão RFID e lê o seu UID.
-
-    Esta função inicializa o leitor MFRC522, espera por um cartão,
-    lê o UID, e depois limpa os pinos GPIO. Ela é projetada para ser
-    chamada em um loop ou em uma thread separada.
+    PT: Aguarda a aproximação de um cartão RFID e lê o seu UID.
+        Esta função inicializa o leitor MFRC522, espera por um cartão,
+        lê o UID, e depois limpa os pinos GPIO. Ela é projetada para ser
+        chamada em um loop ou em uma thread separada.
+    EN: Waits for an RFID card to be presented and reads its UID.
+        This function initializes the MFRC522 reader, waits for a card,
+        reads the UID, and then cleans up the GPIO pins. It is designed
+        to be called in a loop or in a separate thread.
 
     Returns:
-        str: O UID do cartão lido, formatado como uma string (ex: "123-45-67-89"),
-             ou None se a leitura for interrompida.
+        str: PT: O UID do cartão lido, formatado como string (ex: "123-45-67-89"),
+                 ou None se a leitura for interrompida.
+             EN: The UID of the read card, formatted as a string (e.g., "123-45-67-89"),
+                 or None if the reading is interrupted.
     """
-    # Instancia o leitor
+    # PT: Instancia o leitor
+    # EN: Instantiates the reader
     MIFAREReader = MFRC522()
 
-    print("Aproxime o cartão RFID do leitor para leitura...")
+    print("Aproxime o cartão RFID do leitor para leitura... / Approach the RFID card to the reader...")
 
     uid = None
     try:
-        # Loop contínuo para detectar o cartão
+        # PT: Loop contínuo para detectar o cartão
+        # EN: Continuous loop to detect the card
         while True:
-            # MFRC522_Request procura por cartões do tipo PICC (Proximity Integrated Circuit Card)
-            # MI_OK é o status de sucesso
+            # PT: MFRC522_Request procura por cartões do tipo PICC (Proximity Integrated Circuit Card)
+            #     MI_OK é o status de sucesso
+            # EN: MFRC522_Request looks for PICC type cards (Proximity Integrated Circuit Card)
+            #     MI_OK is the success status
             (status, TagType) = MIFAREReader.MFRC522_Request(MIFAREReader.PICC_REQIDL)
 
             if status == MIFAREReader.MI_OK:
-                print("Cartão detectado!")
+                print("Cartão detectado! / Card detected!")
 
-                # MFRC522_Anticoll obtém o UID do cartão
+                # PT: MFRC522_Anticoll obtém o UID do cartão
+                # EN: MFRC522_Anticoll gets the UID of the card
                 (status, uid_bytes) = MIFAREReader.MFRC522_Anticoll()
 
                 if status == MIFAREReader.MI_OK:
-                    # Converte o UID de uma lista de bytes para uma string hifenizada
+                    # PT: Converte o UID de uma lista de bytes para uma string hifenizada
+                    # EN: Converts the UID from a list of bytes to a hyphenated string
                     uid = "-".join(map(str, uid_bytes))
-                    print(f"UID do Cartão: {uid}")
-                    # Retorna o UID e sai da função
+                    print(f"UID do Cartão (Card UID): {uid}")
+                    # PT: Retorna o UID e sai da função
+                    # EN: Returns the UID and exits the function
                     return uid
 
-            # Pequena pausa para não sobrecarregar a CPU
+            # PT: Pequena pausa para não sobrecarregar a CPU
+            # EN: Small pause to avoid overloading the CPU
             time.sleep(0.2)
 
     except KeyboardInterrupt:
-        # Permite que o programa seja interrompido com Ctrl+C
-        print("Leitura de RFID interrompida pelo usuário.")
+        # PT: Permite que o programa seja interrompido com Ctrl+C
+        # EN: Allows the program to be interrupted with Ctrl+C
+        print("Leitura de RFID interrompida pelo usuário. / RFID reading interrupted by user.")
         return None
     finally:
-        # Garante que os pinos GPIO sejam liberados ao final
+        # PT: Garante que os pinos GPIO sejam liberados ao final
+        # EN: Ensures that the GPIO pins are released at the end
         GPIO.cleanup()
 
-# O código abaixo serve para testar este módulo de forma independente.
-# Se você executar `python3 app/rfid.py`, ele irá iniciar o processo de leitura.
+# PT: O código abaixo serve para testar este módulo de forma independente.
+#     Se você executar `python3 app/rfid.py`, ele irá iniciar o processo de leitura.
+# EN: The code below is for testing this module independently.
+#     If you run `python3 app/rfid.py`, it will start the reading process.
 if __name__ == "__main__":
     card_uid = read_uid()
     if card_uid:
-        print(f"\nUID lido com sucesso: {card_uid}")
-        # Exemplo de como usar a função de associação (que ainda está neste arquivo, mas pode ser movida)
-        playlist = "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M" # Exemplo
-        # assign_playlist(card_uid, playlist)
+        print(f"\nUID lido com sucesso (UID read successfully): {card_uid}")
     else:
-        print("\nNenhum UID foi lido.")
+        print("\nNenhum UID foi lido. (No UID was read.)")

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -25,6 +25,40 @@ h2 {
     margin-bottom: 20px;
 }
 
+.header {
+    width: 90%;
+    max-width: 500px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
+
+.lang-switcher {
+    position: absolute;
+    right: 0;
+    top: 0;
+    cursor: pointer;
+    display: flex;
+    gap: 10px;
+}
+
+.lang-switcher span {
+    font-size: 1.5em;
+    opacity: 0.5;
+    transition: opacity 0.2s;
+}
+
+.lang-switcher span:hover {
+    opacity: 1;
+}
+
+.lang-switcher span.active {
+    opacity: 1;
+    transform: scale(1.1);
+}
+
+
 /* --- Container do Player --- */
 .player-container, .upload-container {
     background-color: #1e1e1e;

--- a/app/template/index.html
+++ b/app/template/index.html
@@ -2,15 +2,21 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
-    <title>🎶 Jukebox RFID MP3</title>
+    <title data-i18n-key="title">🎶 Jukebox RFID MP3</title>
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <h1>🎶 Jukebox RFID MP3</h1>
+    <div class="header">
+        <h1 data-i18n-key="title">🎶 Jukebox RFID MP3</h1>
+        <div class="lang-switcher">
+            <span id="lang-pt">🇧🇷</span>
+            <span id="lang-en">🇺🇸</span>
+        </div>
+    </div>
 
     <div class="player-container">
-        <h2>Player</h2>
-        <div id="track-info">Nada tocando...</div>
+        <h2 data-i18n-key="player_title">Player</h2>
+        <div id="track-info" data-i18n-key="nothing_playing">Silêncio...</div>
         <div class="controls">
             <button id="play-pause-btn">▶️</button>
             <div class="volume-control">
@@ -21,25 +27,34 @@
     </div>
 
     <div class="upload-container">
-        <h2>Adicionar Nova Música</h2>
+        <h2 data-i18n-key="upload_title">Adicionar Nova Música</h2>
         <div id="drop-zone">
-            <p>Arraste um arquivo MP3 aqui ou clique para selecionar</p>
+            <p data-i18n-key="drop_zone_text">Arraste um arquivo MP3 aqui ou clique para selecionar</p>
             <input type="file" id="file-input" accept=".mp3" style="display: none;">
         </div>
         <div id="upload-status"></div>
     </div>
 
     <script>
-        const playPauseBtn = document.getElementById('play-pause-btn');
-        const volumeSlider = document.getElementById('volume');
-        const trackInfo = document.getElementById('track-info');
-        const dropZone = document.getElementById('drop-zone');
-        const fileInput = document.getElementById('file-input');
-        const uploadStatus = document.getElementById('upload-status');
+        // --- Seletores de Elementos ---
+        const ui = {
+            playPauseBtn: document.getElementById('play-pause-btn'),
+            volumeSlider: document.getElementById('volume'),
+            trackInfo: document.getElementById('track-info'),
+            dropZone: document.getElementById('drop-zone'),
+            fileInput: document.getElementById('file-input'),
+            uploadStatus: document.getElementById('upload-status'),
+            langPtBtn: document.getElementById('lang-pt'),
+            langEnBtn: document.getElementById('lang-en')
+        };
 
-        // --- Funções da API ---
+        // --- Estado da Aplicação ---
+        let translations = {};
+        let currentLang = localStorage.getItem('jukeboxLang') || 'pt';
 
+        // --- Módulo da API ---
         const api = {
+            getTranslations: () => fetch('/api/translations').then(res => res.json()),
             getStatus: () => fetch('/api/status').then(res => res.json()),
             togglePlayPause: () => fetch('/api/play_pause', { method: 'POST' }).then(res => res.json()),
             setVolume: (level) => fetch('/api/volume', {
@@ -50,95 +65,98 @@
             uploadFile: (file) => {
                 const formData = new FormData();
                 formData.append('file', file);
-                return fetch('/api/upload', {
-                    method: 'POST',
-                    body: formData
-                }).then(res => res.json());
+                return fetch('/api/upload', { method: 'POST', body: formData })
+                    .then(res => res.json());
             }
         };
 
-        // --- Lógica da UI ---
+        // --- Lógica de Internacionalização (i18n) ---
+        function setLanguage(lang) {
+            currentLang = lang;
+            localStorage.setItem('jukeboxLang', lang);
 
-        function updateUI(status) {
-            // Atualiza o nome da música
-            trackInfo.textContent = status.current_song ? `Tocando: ${status.current_song}` : "Silêncio...";
+            document.documentElement.lang = lang;
+            ui.langPtBtn.classList.toggle('active', lang === 'pt');
+            ui.langEnBtn.classList.toggle('active', lang === 'en');
 
-            // Atualiza o botão de play/pause
-            if (status.is_playing) {
-                playPauseBtn.textContent = status.is_paused ? '▶️' : '⏸️';
-            } else {
-                playPauseBtn.textContent = '▶️';
-            }
-
-            // Atualiza o slider de volume
-            volumeSlider.value = status.volume * 100;
+            document.querySelectorAll('[data-i18n-key]').forEach(el => {
+                const key = el.getAttribute('data-i18n-key');
+                if (translations[lang] && translations[lang][key]) {
+                    el.textContent = translations[lang][key];
+                }
+            });
+            // Atualiza a UI do player com o novo idioma
+            api.getStatus().then(updatePlayerUI);
         }
 
-        playPauseBtn.addEventListener('click', () => {
-            api.togglePlayPause().then(updateUI);
-        });
+        // --- Lógica da UI do Player ---
+        function updatePlayerUI(status) {
+            const trackText = status.current_song
+                ? translations[currentLang].now_playing + status.current_song
+                : translations[currentLang].nothing_playing;
+            ui.trackInfo.textContent = trackText;
 
-        volumeSlider.addEventListener('input', (e) => {
-            api.setVolume(e.target.value).then(updateUI);
-        });
+            ui.playPauseBtn.textContent = (status.is_playing && !status.is_paused) ? '⏸️' : '▶️';
+            ui.volumeSlider.value = status.volume * 100;
+        }
 
         // --- Lógica de Upload ---
-
-        dropZone.addEventListener('click', () => fileInput.click());
-
-        dropZone.addEventListener('dragover', (e) => {
-            e.preventDefault();
-            dropZone.classList.add('active');
-        });
-
-        dropZone.addEventListener('dragleave', () => {
-            dropZone.classList.remove('active');
-        });
-
-        dropZone.addEventListener('drop', (e) => {
-            e.preventDefault();
-            dropZone.classList.remove('active');
-            const files = e.dataTransfer.files;
-            if (files.length > 0) {
-                handleFileUpload(files[0]);
-            }
-        });
-
-        fileInput.addEventListener('change', (e) => {
-            if (e.target.files.length > 0) {
-                handleFileUpload(e.target.files[0]);
-            }
-        });
-
         function handleFileUpload(file) {
-            if (file && file.type === 'audio/mpeg') {
-                uploadStatus.textContent = `Enviando ${file.name}...`;
-                api.uploadFile(file).then(response => {
-                    uploadStatus.textContent = response.message;
-                    if (response.status === 'success') {
-                        // Após o sucesso, atualiza o status para mostrar a nova música se ela começar a tocar
-                        setTimeout(api.getStatus, 1000).then(updateUI);
-                    }
-                }).catch(err => {
-                    uploadStatus.textContent = 'Erro no envio.';
-                    console.error(err);
-                });
-            } else {
-                uploadStatus.textContent = 'Por favor, selecione um arquivo MP3.';
+            if (!file || file.type !== 'audio/mpeg') {
+                ui.uploadStatus.textContent = translations[currentLang].upload_status_invalid;
+                return;
+            }
+            ui.uploadStatus.textContent = translations[currentLang].upload_status_uploading + file.name + '...';
+            api.uploadFile(file).then(response => {
+                // A mensagem de sucesso/erro do backend já é em texto plano, não precisa de tradução aqui
+                // Mas podemos traduzir a parte genérica.
+                if (response.status === 'success') {
+                    ui.uploadStatus.textContent = `✅ ${file.name}` + translations[currentLang].upload_status_success;
+                } else {
+                    ui.uploadStatus.textContent = `❌ ` + translations[currentLang].upload_status_error;
+                }
+                setTimeout(api.getStatus, 1500).then(updatePlayerUI);
+            }).catch(err => {
+                ui.uploadStatus.textContent = '❌ ' + translations[currentLang].upload_status_error;
+                console.error(err);
+            });
+        }
+
+        // --- Event Listeners ---
+        ui.playPauseBtn.addEventListener('click', () => api.togglePlayPause().then(updatePlayerUI));
+        ui.volumeSlider.addEventListener('input', (e) => api.setVolume(e.target.value));
+        ui.langPtBtn.addEventListener('click', () => setLanguage('pt'));
+        ui.langEnBtn.addEventListener('click', () => setLanguage('en'));
+        ui.dropZone.addEventListener('click', () => ui.fileInput.click());
+        ui.fileInput.addEventListener('change', (e) => handleFileUpload(e.target.files[0]));
+
+        // Drag & Drop listeners
+        ['dragover', 'dragleave', 'drop'].forEach(eventName => {
+            ui.dropZone.addEventListener(eventName, (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+            }, false);
+        });
+        ui.dropZone.addEventListener('dragover', () => ui.dropZone.classList.add('active'));
+        ui.dropZone.addEventListener('dragleave', () => ui.dropZone.classList.remove('active'));
+        ui.dropZone.addEventListener('drop', (e) => {
+            ui.dropZone.classList.remove('active');
+            handleFileUpload(e.dataTransfer.files[0]);
+        });
+
+        // --- Inicialização ---
+        async function initialize() {
+            try {
+                translations = await api.getTranslations();
+                setLanguage(currentLang);
+                setInterval(() => api.getStatus().then(updatePlayerUI), 3000);
+            } catch (error) {
+                console.error("Falha ao inicializar a aplicação:", error);
+                document.body.innerHTML = "<h1>Erro ao carregar a Jukebox. Verifique o console.</h1>";
             }
         }
 
-        // --- Polling de Status ---
-
-        // Inicia o polling para manter a UI sincronizada com o backend
-        setInterval(() => {
-            api.getStatus().then(updateUI);
-        }, 3000); // Atualiza a cada 3 segundos
-
-        // Carrega o status inicial
-        document.addEventListener('DOMContentLoaded', () => {
-            api.getStatus().then(updateUI);
-        });
+        document.addEventListener('DOMContentLoaded', initialize);
     </script>
 </body>
 </html>

--- a/app/translations.json
+++ b/app/translations.json
@@ -1,0 +1,26 @@
+{
+    "pt": {
+        "title": "🎶 Jukebox RFID MP3",
+        "player_title": "Player",
+        "upload_title": "Adicionar Nova Música",
+        "now_playing": "Tocando: ",
+        "nothing_playing": "Silêncio...",
+        "drop_zone_text": "Arraste um arquivo MP3 aqui ou clique para selecionar",
+        "upload_status_uploading": "Enviando ",
+        "upload_status_error": "Erro no envio.",
+        "upload_status_success": " salvo. Aproxime um cartão para associar.",
+        "upload_status_invalid": "Por favor, selecione um arquivo MP3."
+    },
+    "en": {
+        "title": "🎶 RFID MP3 Jukebox",
+        "player_title": "Player",
+        "upload_title": "Add New Song",
+        "now_playing": "Now Playing: ",
+        "nothing_playing": "Silence...",
+        "drop_zone_text": "Drag & drop an MP3 file here or click to select",
+        "upload_status_uploading": "Uploading ",
+        "upload_status_error": "Upload error.",
+        "upload_status_success": " saved. Scan a card to associate.",
+        "upload_status_invalid": "Please select an MP3 file."
+    }
+}

--- a/install.sh
+++ b/install.sh
@@ -35,24 +35,31 @@ if [ "$opcao" == "1" ]; then
     curl -sL https://dtcooper.github.io/raspotify/install.sh | sh || { echo "❌ Falha ao instalar Raspotify"; exit 1; }
 
     echo "🛠️ Configurando serviço..."
-    # Obtém o diretório absoluto do script para evitar problemas com caminhos relativos.
+    # PT: Obtém o diretório absoluto do script para evitar problemas com caminhos relativos.
+    # EN: Gets the absolute directory of the script to avoid problems with relative paths.
     SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
-    # Cria o arquivo de serviço do systemd dinamicamente com os caminhos corretos.
-    # Isso torna a instalação independente do local onde o repositório foi clonado.
+    # PT: Cria o arquivo de serviço do systemd dinamicamente com os caminhos corretos.
+    # PT: Isso torna a instalação independente do local onde o repositório foi clonado.
+    # EN: Dynamically creates the systemd service file with the correct paths.
+    # EN: This makes the installation independent of where the repository was cloned.
     sudo tee /etc/systemd/system/jukebox.service > /dev/null <<EOF
 [Unit]
 Description=Jukebox RFID Web Server
 After=network.target
 
 [Service]
-# Executa o main.py usando o Python do ambiente virtual (venv).
+# PT: Executa o main.py usando o Python do ambiente virtual (venv).
+# EN: Executes main.py using the Python from the virtual environment (venv).
 ExecStart=$SCRIPT_DIR/venv/bin/python3 $SCRIPT_DIR/app/main.py
-# Define o diretório de trabalho para a pasta da aplicação.
+# PT: Define o diretório de trabalho para a pasta da aplicação.
+# EN: Sets the working directory to the application folder.
 WorkingDirectory=$SCRIPT_DIR/app
 Restart=always
-# É recomendado rodar o serviço com um usuário não-root que tenha as permissões necessárias.
-# O usuário 'pi' é o padrão no Raspberry Pi OS.
+# PT: É recomendado rodar o serviço com um usuário não-root que tenha as permissões necessárias.
+# PT: O usuário 'pi' é o padrão no Raspberry Pi OS.
+# EN: It is recommended to run the service with a non-root user who has the necessary permissions.
+# EN: The 'pi' user is the default on Raspberry Pi OS.
 User=pi
 
 [Install]
@@ -60,11 +67,14 @@ WantedBy=multi-user.target
 EOF
 
     echo "🔄 Recarregando e reiniciando o serviço systemd..."
-    # Recarrega o systemd para que ele leia o novo arquivo de serviço.
+    # PT: Recarrega o systemd para que ele leia o novo arquivo de serviço.
+    # EN: Reloads systemd so it reads the new service file.
     sudo systemctl daemon-reload
-    # Habilita o serviço para iniciar no boot.
+    # PT: Habilita o serviço para iniciar no boot.
+    # EN: Enables the service to start on boot.
     sudo systemctl enable jukebox.service
-    # Reinicia o serviço para aplicar as novas configurações.
+    # PT: Reinicia o serviço para aplicar as novas configurações.
+    # EN: Restarts the service to apply the new settings.
     sudo systemctl restart jukebox.service || { echo "❌ Falha ao iniciar serviço"; exit 1; }
 
     echo "📱 Gerando QR Code..."


### PR DESCRIPTION
This commit adds comprehensive support for both Portuguese (pt) and English (en) throughout the application.

Key changes:

- **Client-Side Language Switching:**
  - The web interface now features an instant language switcher (🇧🇷 / 🇺🇸 flags) that does not require a page reload.
  - All UI text is now dynamically rendered from a central translation source.
  - User's language preference is saved in the browser's `localStorage`.

- **Backend Translation API:**
  - A new `app/translations.json` file has been created to store all UI strings for both languages.
  - A new `/api/translations` endpoint serves this data to the frontend.

- **Bilingual Code Comments:**
  - All code comments in `install.sh`, `main.py`, `player.py`, and `rfid.py` have been updated to be bilingual (Portuguese and English) for better maintainability.

- **Updated Documentation:**
  - The `README.md` file has been updated to be fully bilingual, with complete and parallel guides for both languages.
  - The new language-switching feature is now documented in the "How to Use" section.