### PR TITLE
fix: Correct JavaScript error on file upload

### DIFF
--- a/app/template/index.html
+++ b/app/template/index.html
@@ -120,7 +120,7 @@
                 } else {
                     ui.uploadStatus.textContent = `❌ ` + (translations[currentLang]?.upload_status_error || 'Upload error.');
                 }
-                setTimeout(api.getStatus, 1500).then(updatePlayerUI);
+                setTimeout(() => { api.getStatus().then(updatePlayerUI); }, 1500);
             }).catch(err => {
                 ui.uploadStatus.textContent = '❌ ' + (translations[currentLang]?.upload_status_error || 'Upload error.');
                 console.error(err);


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred after a file upload. The `setTimeout` function was being used with a `.then()` promise-style callback, which is not supported.

The code has been corrected to use a proper anonymous function callback, which restores the status update functionality after an upload completes.