### PR TITLE
feat: Add initial library and tag management UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -292,10 +292,17 @@ def get_library():
         with cache_lock:
             associations = dict(tag_cache)
 
-        return jsonify({
+        response = jsonify({
             "songs": songs,
             "associations": associations
         })
+        # PT: Evita que o navegador guarde a lista em cache.
+        # EN: Prevents the browser from caching the list.
+        response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+        response.headers['Pragma'] = 'no-cache'
+        response.headers['Expires'] = '0'
+        return response
+
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)}), 500
 


### PR DESCRIPTION
This commit introduces the initial version of the library and tag management feature.

- Adds new API endpoints: `/api/library` to fetch all songs and tags, `/api/play/<filename>` to play songs directly, and `DELETE /api/association/<tag_id>` to remove tag associations.
- Restructures the frontend into a tabbed interface (Player, Library, Tags).
- Implements a view of the music library with play buttons.
- Implements a view of tag associations with delete buttons.
- Fixes a browser caching issue that prevented the library view from updating after a new song upload.