### PR TITLE
feat: Add library and tag management features

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -276,3 +276,34 @@ input[type="range"] {
 .delete-btn:hover {
     background-color: #d9534f; /* Vermelho mais claro */
 }
+
+.song-controls {
+    display: flex;
+    gap: 10px;
+}
+
+.tag-label {
+    color: #1DB954; /* Verde */
+    font-size: 0.9em;
+}
+
+.no-tag-label {
+    color: #aaa; /* Cinza */
+    font-size: 0.9em;
+    font-style: italic;
+}
+
+.assign-btn {
+    background-color: #f0ad4e; /* Laranja */
+    color: white;
+    border: none;
+    border-radius: 5px;
+    padding: 5px 10px;
+    cursor: pointer;
+    font-size: 0.8em;
+    transition: background-color 0.2s;
+}
+
+.assign-btn:hover {
+    background-color: #ec971f;
+}

--- a/app/template/index.html
+++ b/app/template/index.html
@@ -18,6 +18,7 @@
         <a href="#" class="nav-link active" data-page="player" data-i18n-key="nav_player">Player</a>
         <a href="#" class="nav-link" data-page="library" data-i18n-key="nav_library">Biblioteca</a>
         <a href="#" class="nav-link" data-page="tags" data-i18n-key="nav_tags">Tags</a>
+        <a href="#" class="nav-link" data-page="test" data-i18n-key="nav_test">Teste RFID</a>
     </nav>
 
     <main id="page-player" class="page active">
@@ -32,7 +33,9 @@
                 </div>
             </div>
         </div>
+    </main>
 
+    <main id="page-library" class="page" style="display: none;">
         <div class="upload-container">
             <h2 data-i18n-key="upload_title">Adicionar Nova Música</h2>
             <div id="drop-zone">
@@ -42,13 +45,6 @@
             <div id="upload-status"></div>
         </div>
 
-        <div class="rfid-test-container">
-            <h2 data-i18n-key="rfid_test_title">Teste de Cartão RFID</h2>
-            <div id="rfid-status" data-i18n-key="rfid_waiting">Aguardando um cartão...</div>
-        </div>
-    </main>
-
-    <main id="page-library" class="page" style="display: none;">
         <div class="library-container">
             <h2 data-i18n-key="library_title">Biblioteca de Músicas</h2>
             <ul id="song-list">
@@ -63,6 +59,13 @@
             <div id="tag-list">
                 <!-- A lista de associações de tags será inserida aqui pelo JavaScript -->
             </div>
+        </div>
+    </main>
+
+    <main id="page-test" class="page" style="display: none;">
+        <div class="rfid-test-container">
+            <h2 data-i18n-key="rfid_test_title">Teste de Cartão RFID</h2>
+            <div id="rfid-status" data-i18n-key="rfid_waiting">Aguardando um cartão...</div>
         </div>
     </main>
 
@@ -91,6 +94,11 @@
             getStatus: () => fetch('/api/status').then(res => res.json()),
             getLibrary: () => fetch('/api/library').then(res => res.json()),
             deleteAssociation: (tagId) => fetch(`/api/association/${tagId}`, { method: 'DELETE' }).then(res => res.json()),
+            initiateAssociation: (filename) => fetch('/api/initiate_association', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ filename })
+            }).then(res => res.json()),
             togglePlayPause: () => fetch('/api/play_pause', { method: 'POST' }).then(res => res.json()),
             playSong: (filename) => fetch(`/api/play/${filename}`, { method: 'POST' }).then(res => res.json()),
             setVolume: (level) => fetch('/api/volume', {
@@ -145,13 +153,14 @@
             ui.uploadStatus.textContent = (translations[currentLang]?.upload_status_uploading || 'Uploading ') + file.name + '...';
             api.uploadFile(file).then(response => {
                 if (response.status === 'success') {
-                    ui.uploadStatus.textContent = `✅ ${file.name} ` + (translations[currentLang]?.upload_status_success || 'saved. Scan a card to associate.');
+                    ui.uploadStatus.textContent = `✅ ${response.message}`;
+                    // Atualiza a lista de músicas na biblioteca após o upload.
+                    api.getLibrary().then(renderLibrary);
                 } else {
-                    ui.uploadStatus.textContent = `❌ ` + (translations[currentLang]?.upload_status_error || 'Upload error.');
+                    ui.uploadStatus.textContent = `❌ ${response.message}`;
                 }
-                setTimeout(() => { api.getStatus().then(updatePlayerUI); }, 1500);
             }).catch(err => {
-                ui.uploadStatus.textContent = '❌ ' + (translations[currentLang]?.upload_status_error || 'Upload error.');
+                ui.uploadStatus.textContent = '❌ ' + (translations[currentLang]?.upload_status_error_generic || 'An error occurred during upload.');
                 console.error(err);
             });
         }
@@ -166,9 +175,25 @@
                 return;
             }
 
+            // Inverte o mapa de associações para fácil busca (música -> tag)
+            const songToTagMap = Object.entries(library.associations).reduce((acc, [tag, song]) => {
+                acc[song] = tag;
+                return acc;
+            }, {});
+
             library.songs.forEach(song => {
                 const li = document.createElement('li');
-                li.textContent = song;
+
+                const songInfo = document.createElement('span');
+                const associatedTag = songToTagMap[song];
+                if (associatedTag) {
+                    songInfo.innerHTML = `${song} <span class="tag-label">(${translations[currentLang]?.song_tag_label || 'Tag'}: ${associatedTag})</span>`;
+                } else {
+                    songInfo.innerHTML = `${song} <span class="no-tag-label">(${translations[currentLang]?.song_no_tag_label || 'Sem Tag'})</span>`;
+                }
+
+                const controlsDiv = document.createElement('div');
+                controlsDiv.className = 'song-controls';
 
                 const playButton = document.createElement('button');
                 playButton.textContent = '▶️';
@@ -176,12 +201,30 @@
                 playButton.onclick = () => {
                     api.playSong(song).then(response => {
                         console.log(response);
-                        // Opcional: atualizar o status do player imediatamente
                         setTimeout(() => api.getStatus().then(updatePlayerUI), 500);
                     });
                 };
 
-                li.appendChild(playButton);
+                const assignButton = document.createElement('button');
+                assignButton.className = 'assign-btn';
+                assignButton.textContent = associatedTag ? (translations[currentLang]?.btn_change_tag || 'Mudar Tag') : (translations[currentLang]?.btn_assign_tag || 'Associar Tag');
+                assignButton.onclick = () => {
+                    api.initiateAssociation(song).then(response => {
+                        if (response.status === 'success') {
+                            // Mostra a mensagem no status de upload, que é uma área de status global
+                            ui.uploadStatus.textContent = `⏳ ${response.message}`;
+                            // Leva o usuário de volta para a página de teste de RFID para que ele possa ver o status
+                            document.querySelector('.nav-link[data-page="test"]').click();
+                        } else {
+                            ui.uploadStatus.textContent = `❌ ${response.message}`;
+                        }
+                    });
+                };
+
+                controlsDiv.appendChild(playButton);
+                controlsDiv.appendChild(assignButton);
+                li.appendChild(songInfo);
+                li.appendChild(controlsDiv);
                 songList.appendChild(li);
             });
         }

--- a/app/translations.json
+++ b/app/translations.json
@@ -4,6 +4,7 @@
         "nav_player": "Player",
         "nav_library": "Biblioteca",
         "nav_tags": "Tags",
+        "nav_test": "Teste RFID",
         "player_title": "Player",
         "upload_title": "Adicionar Nova Música",
         "rfid_test_title": "Teste de Cartão RFID",
@@ -13,8 +14,7 @@
         "nothing_playing": "Silêncio...",
         "drop_zone_text": "Arraste um arquivo MP3 aqui ou clique para selecionar",
         "upload_status_uploading": "Enviando ",
-        "upload_status_error": "Erro no envio.",
-        "upload_status_success": " salvo. Aproxime um cartão para associar.",
+        "upload_status_error_generic": "Ocorreu um erro durante o envio.",
         "upload_status_invalid": "Por favor, selecione um arquivo MP3.",
         "rfid_waiting": "Aguardando um cartão...",
         "rfid_associated": "Associado",
@@ -25,13 +25,18 @@
         "table_header_song": "Música Associada",
         "table_header_actions": "Ações",
         "btn_delete": "Deletar",
-        "confirm_delete": "Tem certeza que deseja deletar a associação para a tag"
+        "btn_assign_tag": "Associar Tag",
+        "btn_change_tag": "Mudar Tag",
+        "confirm_delete": "Tem certeza que deseja deletar a associação para a tag",
+        "song_tag_label": "Tag",
+        "song_no_tag_label": "Sem Tag"
     },
     "en": {
         "title": "🎶 RFID MP3 Jukebox",
         "nav_player": "Player",
         "nav_library": "Library",
         "nav_tags": "Tags",
+        "nav_test": "RFID Test",
         "player_title": "Player",
         "upload_title": "Add New Song",
         "rfid_test_title": "RFID Card Test",
@@ -41,8 +46,7 @@
         "nothing_playing": "Silence...",
         "drop_zone_text": "Drag & drop an MP3 file here or click to select",
         "upload_status_uploading": "Uploading ",
-        "upload_status_error": "Upload error.",
-        "upload_status_success": " saved. Scan a card to associate.",
+        "upload_status_error_generic": "An error occurred during upload.",
         "upload_status_invalid": "Please select an MP3 file.",
         "rfid_waiting": "Waiting for a card...",
         "rfid_associated": "Associated",
@@ -53,6 +57,10 @@
         "table_header_song": "Associated Song",
         "table_header_actions": "Actions",
         "btn_delete": "Delete",
-        "confirm_delete": "Are you sure you want to delete the association for tag"
+        "btn_assign_tag": "Assign Tag",
+        "btn_change_tag": "Change Tag",
+        "confirm_delete": "Are you sure you want to delete the association for tag",
+        "song_tag_label": "Tag",
+        "song_no_tag_label": "No Tag"
     }
 }


### PR DESCRIPTION
This major feature update adds a comprehensive management interface to the Jukebox, allowing users to view their music library, play songs directly from the UI, and manage RFID tag associations.

Key additions:
- New API endpoints: `/api/library` to fetch all songs and tags, `/api/play/<filename>` to play songs directly, `/api/association/<tag_id>` to remove associations, and `/api/initiate_association` to start the assignment process for a specific song.
- Decoupled Logic: The file upload process is now separate from tag assignment, providing a more flexible workflow.
- Tabbed UI: The frontend is now organized into "Player", "Library", "Tags", and "Test" tabs for better navigation and clarity.
- Enhanced Music Library: The Library tab now displays all songs, shows their current tag association status, and provides buttons to play or assign a tag.
- Tag Management: The Tags tab displays all current associations and allows for their deletion.